### PR TITLE
An attempt at robust visibility management.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build*/
 /.vs
+.idea/

--- a/src/Events.cpp
+++ b/src/Events.cpp
@@ -28,10 +28,8 @@ RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuO
 	// On HUD menu open/close - open/close the plugin's HUD menu
 	if (a_event && (a_event->menuName == RE::HUDMenu::MENU_NAME || a_event->menuName == "TrueHUD"sv)) {
 		if (a_event->opening) {
-			logger::info("Showing oxygen meter after HUD opening.");
 			oxygenMenu::Show();
 		} else {
-			logger::info("Hiding oxygen meter after HUD closing.");
 			oxygenMenu::Hide();
 		}
 	}

--- a/src/Events.cpp
+++ b/src/Events.cpp
@@ -14,19 +14,24 @@ MenuOpenCloseEventHandler* MenuOpenCloseEventHandler::GetSingleton()
 void MenuOpenCloseEventHandler::Register()
 {
 	auto ui = RE::UI::GetSingleton();
-	ui->AddEventSink(GetSingleton());
+	ui->AddEventSink<RE::MenuOpenCloseEvent>(GetSingleton());
+	logger::info("Registered {}"sv, typeid(RE::MenuOpenCloseEvent).name());
 }
 
 RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
 {
 	// from ersh TrueHud pretty much verbatim
+	if (a_event)
+		logger::debug("Received RE::MenuOpenCloseEvent for {} with opening {}"sv, a_event->menuName, a_event->opening);
 
 	using ContextID = RE::UserEvents::INPUT_CONTEXT_ID;
 	// On HUD menu open/close - open/close the plugin's HUD menu
-	if (a_event && a_event->menuName == RE::HUDMenu::MENU_NAME) {
+	if (a_event && (a_event->menuName == RE::HUDMenu::MENU_NAME || a_event->menuName == "TrueHUD"sv)) {
 		if (a_event->opening) {
+			logger::info("Showing oxygen meter after HUD opening.");
 			oxygenMenu::Show();
 		} else {
+			logger::info("Hiding oxygen meter after HUD closing.");
 			oxygenMenu::Hide();
 		}
 	}
@@ -36,15 +41,15 @@ RE::BSEventNotifyControl MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuO
 	if (controlMap) {
 		auto& priorityStack = controlMap->contextPriorityStack;
 		if (priorityStack.empty()) {
-			oxygenMenu::SetMenuVisibilityMode(oxygenMenu::MenuVisibilityMode::kHidden);
-		} 
+			oxygenMenu::want_visible = false;
+		}
 		else if (priorityStack.back() == ContextID::kGameplay ||
 				 priorityStack.back() == ContextID::kFavorites ||
 				 priorityStack.back() == ContextID::kConsole) 
 		{
-			oxygenMenu::SetMenuVisibilityMode(oxygenMenu::MenuVisibilityMode::kVisible);
+			oxygenMenu::want_visible = true;
 		} else {
-			oxygenMenu::SetMenuVisibilityMode(oxygenMenu::MenuVisibilityMode::kHidden);
+			oxygenMenu::want_visible = false;
 		}
 	}
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -29,8 +29,11 @@ public:
 		ini::get_value(ini, widget_xscale, "Position", "Widget X scale", ";The X scale of the widget, default is 75.000000");
 		ini::get_value(ini, widget_yscale, "Position", "Widget Y scale", ";The Y scale of the widget, default is 75.000000");
 
-		widget_xpos = std::clamp(widget_xpos, 0.0f, 100.0f);
-		widget_ypos = std::clamp(widget_ypos, 0.0f, 100.0f);
+		if (widget_xpos > 100.0f || widget_xpos < 0.0f)
+			widget_xpos = 50.0f;
+
+		if (widget_ypos > 100.0f || widget_ypos < 0.0f)
+			widget_ypos = 96.3f;
 
 		ini.SaveFile(path);
 	}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 
 class Settings
 {
@@ -22,11 +23,14 @@ public:
 		ini::get_value(ini, flashWhenBelow, "Settings", "Flash meter when air level below", ";Oxygen meter starts to flash when under this percentage of total air, default is 50");
 		ini::get_value(ini, widget_colour, "Colour", "Widget Bar Colour", ";The colour of the widget bar, default is 0x51CCCC");
 		ini::get_value(ini, widget_flashcolour, "Colour", "Widget Flash Colour", ";The colour of the flash effect around the widget, default is 0x51CCCC");
-		ini::get_value(ini, widget_xpos, "Position", "Widget X Position", ";The X Position for the widget, default is 961.000000");
-		ini::get_value(ini, widget_ypos, "Position", "Widget Y Position", ";The Y Position for the widget, default is 1040.000000");
+		ini::get_value(ini, widget_xpos, "Position", "Widget X Position", ";The X Position for the widget as a percentage, default is 50.0");
+		ini::get_value(ini, widget_ypos, "Position", "Widget Y Position", ";The Y Position for the widget as a percentage, default is 96.3");
 		ini::get_value(ini, widget_rotation, "Position", "Widget Rotation", ";The rotation for the widget, default is 0.000000");
 		ini::get_value(ini, widget_xscale, "Position", "Widget X scale", ";The X scale of the widget, default is 75.000000");
 		ini::get_value(ini, widget_yscale, "Position", "Widget Y scale", ";The Y scale of the widget, default is 75.000000");
+
+		widget_xpos = std::clamp(widget_xpos, 0.0f, 100.0f);
+		widget_ypos = std::clamp(widget_ypos, 0.0f, 100.0f);
 
 		ini.SaveFile(path);
 	}
@@ -35,8 +39,8 @@ public:
 	float flashWhenBelow{ 50.0f };
 	std::uint32_t widget_colour{ 0x51CCCC };
 	std::uint32_t widget_flashcolour{ 0x51CCCC };
-	float widget_xpos{ 961.0f };
-	float widget_ypos{ 1040.0f };
+	float widget_xpos{ 50.0f };
+	float widget_ypos{ 96.3f };
 	float widget_rotation{ 0.0f };
 	float widget_xscale{ 75.0f };
 	float widget_yscale{ 75.0f };

--- a/src/oxyMeter.cpp
+++ b/src/oxyMeter.cpp
@@ -223,9 +223,6 @@ void oxygenMenu::OnClose()
 
 void oxygenMenu::SetMenuVisibilityMode(MenuVisibilityMode a_mode)
 {
-	// This does the exact same thing as sending show and hide messages. You can see the events being caught
-	// with OnOpen and OnClose.
-
 	auto menu = GetOxygenMenu();
 	if (menu) {
 		auto _view = menu->uiMovie;

--- a/src/oxyMeter.h
+++ b/src/oxyMeter.h
@@ -29,6 +29,7 @@ public:
 		kVisible
 	};
 	MenuVisibilityMode _menuVisibilityMode = MenuVisibilityMode::kVisible;
+	static inline bool want_visible{ false };
 
 	static void SetMenuVisibilityMode(MenuVisibilityMode a_mode);
 	bool IsOpen() const;


### PR DESCRIPTION
This corrects all scenarios where the widget is prematurely made
visible or fails to become visible that I could think to test:

* New game from fresh load
* New game after quitting to menu from loaded game
* Loading game indoors
* Loading game outdoors
* Loading game underwater
* Loading game underwater, quitting to menu, then loading another game above water.
* Loading game above water, quitting to menu, then loading another game below water
* Opening chests, fast traveling, opening skills menu both above and below water.

There's also a change to switch the position from pixel coordinates to a percentage instead so behavior is stable for non 1080p users.

I don't like that visibility is checked every frame, but I could not find a way to this event based with the current state of CommonLibSSE.